### PR TITLE
buffer: Fix underlying memory reused wrongly

### DIFF
--- a/buffer/bytes.go
+++ b/buffer/bytes.go
@@ -33,7 +33,9 @@ func (b *BytesBuffer) Cap() int {
 
 // Bytes returns a mutable reference to the underlying byte slice.
 func (b *BytesBuffer) Bytes() []byte {
-	return b.bs
+	s := make([]byte, len(b.bs))
+	copy(s, b.bs)
+	return s
 }
 
 // String returns a string copy of the underlying byte slice.


### PR DESCRIPTION
Currently, we return the underlying bytes directly in `buffer.Bytes()`.
But the underlying bytes could be reused after `buffer.Free()` and
before we actually read it. This commit will fix this issue by made a
copy before returning.

ref: https://blog.golang.org/go-slices-usage-and-internals

Signed-off-by: Xuanwo <xuanwo.cn@gmail.com>